### PR TITLE
use std::time::Instant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ include = [
 ]
 
 [dependencies]
-time = "^0.1"
 rand = "^0.3"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Add the `statsd` package as a dependency in your `Cargo.toml` file:
 statsd = "^0.9.0"
 ```
 
+You need rustc >= 1.8.0 for statsd to work.
+
 You can then get a client instance and start tracking metrics:
 
 ```rust


### PR DESCRIPTION
This one is monotonic, not affected by manual system time changes.

This API is introduced in Rust 1.8.0 but it's already quite old. (Ubuntu has at least 1.15, Debian 1.14.)