### PR TITLE
Histogram metrics

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::error;
 use std::fmt;
 use std::io::Error;
 use std::net::AddrParseError;
@@ -31,15 +30,6 @@ impl fmt::Display for StatsdError {
         match *self {
             StatsdError::IoError(ref e) => write!(f, "{}", e),
             StatsdError::AddrParseError(ref e) => write!(f, "{}", e),
-        }
-    }
-}
-
-impl error::Error for StatsdError {
-    fn description(&self) -> &str {
-        match *self {
-            StatsdError::IoError(ref e) => e.description(),
-            StatsdError::AddrParseError(ref e) => e,
         }
     }
 }
@@ -217,6 +207,17 @@ impl Client {
     pub fn pipeline(&self) -> Pipeline {
         Pipeline::new()
     }
+
+    /// Send a histogram value.
+    ///
+    /// ```ignore
+    /// // pass response size value
+    /// client.histogram("response.size", 128.0);
+    /// ```
+    pub fn histogram(&self, metric: &str, value: f64) {
+        let data = self.prepare(format!("{}:{}|h", metric, value));
+        self.send(data);
+    }
 }
 
 pub struct Pipeline {
@@ -365,6 +366,20 @@ impl Pipeline {
         callable();
         let used = start.elapsed();
         let data = format!("{}:{}|ms", metric, used.as_millis());
+        self.stats.push_back(data);
+    }
+
+    /// Send a histogram value.
+    ///
+    /// ```
+    /// use statsd::client::Pipeline;
+    ///
+    /// let mut pipe = Pipeline::new();
+    /// // pass response size value
+    /// pipe.histogram("response.size", 128.0);
+    /// ```
+    pub fn histogram(&mut self, metric: &str, value: f64) {
+        let data = format!("{}:{}|h", metric, value);
         self.stats.push_back(data);
     }
 
@@ -530,6 +545,18 @@ mod test {
     }
 
     #[test]
+    fn test_sending_histogram() {
+        let host = next_test_ip4();
+        let server = make_server(&host);
+        let client = Client::new(&host, "myapp").unwrap();
+
+        client.histogram("metric", 9.1);
+
+        let response = server_recv(server);
+        assert_eq!("myapp.metric:9.1|h", response);
+    }
+
+    #[test]
     fn test_pipeline_sending_time_block() {
         let host = next_test_ip4();
         let server = make_server(&host);
@@ -562,6 +589,19 @@ mod test {
 
         let response = server_recv(server);
         assert_eq!("myapp.metric:9.1|g", response);
+    }
+
+    #[test]
+    fn test_pipeline_sending_histogram() {
+        let host = next_test_ip4();
+        let server = make_server(&host);
+        let client = Client::new(&host, "myapp").unwrap();
+        let mut pipeline = client.pipeline();
+        pipeline.histogram("metric", 9.1);
+        pipeline.send(&client);
+
+        let response = server_recv(server);
+        assert_eq!("myapp.metric:9.1|h", response);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
-use std::fmt;
 use std::error;
+use std::fmt;
 use std::io::Error;
 use std::net::AddrParseError;
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::fmt;
+use std::error;
 use std::io::Error;
 use std::net::AddrParseError;
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
@@ -33,6 +34,8 @@ impl fmt::Display for StatsdError {
         }
     }
 }
+
+impl error::Error for StatsdError {}
 
 /// Client socket for statsd servers.
 ///


### PR DESCRIPTION
`histogram` function is the only thing this great tiny lib missed. Let's add it :-)
P.S. `Error::description` is deprecated since 1.42 Rust version and produces warnings on newer compiler versions. Removed it