### PR TITLE
update dependency; improve tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ include = [
     "README.md",
     "LICENSE.txt",
 ]
+edition = "2018"
 
 [dependencies]
-rand = "^0.3"
+rand = "0.8"
+
+[dev-dependencies]
+itertools = "0.10"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the `statsd` package as a dependency in your `Cargo.toml` file:
 statsd = "^0.13.1"
 ```
 
-You need rustc >= 1.8.0 for statsd to work.
+You need rustc >= 1.31.0 for statsd to work.
 
 You can then get a client instance and start tracking metrics:
 


### PR DESCRIPTION
Changes:

 - bumps `rand` from 0.3 to 0.8
 - bumps to 2018 edition and corresponding MSRV
 - adds trivial implementation of `Default` for `Pipeline` to assuage clippy
 - rewrites tests to no longer sometimes fail when ports collide
 - rewrites tests to actually test stuff that sends multiple UDP packets